### PR TITLE
Added tons of cell formatting options

### DIFF
--- a/report.js
+++ b/report.js
@@ -156,8 +156,6 @@ function SimpleRow(cells, width, fontSize) {
     for (var idx = 0; idx < cellCount; idx++) {
       rtf += "\\pard\\intbl\\nowidctlpar\\f1\\fs" + this.fontSize + "\n";
       rtf += this.cells[idx].toRtf() + "\\cell";
-      if(this.cells[idx].fontSize !== null && this.cells[idx].fontSize != this.fontSize)
-        rtf += "\\fs" + this.fontSize + "\n";
     }
 
     rtf += "\\pard\\intbl\\row";
@@ -242,13 +240,11 @@ function NestedRow(cells, width, fontSize) {
           rtf += "\\cellx" + (cell.width > 0 ? cell.width : varOffset) + "\\nestrow}{\\nonesttables\\par}";
         }
       }
-      if(this.cells[idx].fontSize !== null && this.cells[idx].fontSize != this.fontSize)
-        rtf += "\\fs" + this.fontSize + "\n";
     }
 
     // case simple-nextes
     if (mayEnter) {
-      rtf += "\\pard\\intbl\\nowidctlpar\\cell";
+      rtf += "\\pard\\intbl\\nowidctlpar" + this.fontSize + "\n\\cell";
     }
     rtf += "\\trowd\\trgaph70\\trleft-108";
 

--- a/report.js
+++ b/report.js
@@ -157,7 +157,7 @@ function SimpleRow(cells, width, fontSize) {
       rtf += "\\pard\\intbl\\nowidctlpar\\f1\\fs" + this.fontSize + "\n";
       rtf += this.cells[idx].toRtf() + "\\cell";
       if(this.cells[idx].fontSize !== null && this.cells[idx].fontSize != this.fontSize)
-        rtf += "\\fs" + this.fontSize + " ";
+        rtf += "\\fs" + this.fontSize + "\n";
     }
 
     rtf += "\\pard\\intbl\\row";
@@ -479,6 +479,7 @@ function Cell(content) {
 //
 // @example: A row with four columns, where the first three are empty.
 //  table.addSimpleRow(Cell.blank(), Cell.blank(), Cell.blank(), new Cell("4th column"))
+// @param width [Integer, optional] the width of the blank cell
 Cell.blank = function() {
   return new Cell("", arguments.length > 0 ? arguments[0] : 0);
 };


### PR DESCRIPTION
Among them are font size, cell text alignment and cell borders.

Also fixed a minor bug. Spaces were being used to seperate out rtf tags from the actual text content which caused a space to appear before the content in some of the table cells. I switched all of those over to newlines, which don't have that issue. Otherwise we would've needed to track the amount of spacing inserted at every branch or store each tag seperately and then  insert the necessary spacing at the end in an additional step.